### PR TITLE
feat(presentational): add Color HOC and Notification component

### DIFF
--- a/src/web/components/Notification/Notification.test.js
+++ b/src/web/components/Notification/Notification.test.js
@@ -10,7 +10,7 @@ describe('Notification', () => {
   beforeEach(() => {
     content = <p>Hello World</p>;
     onClose = jest.fn();
-    wrapper = shallow(<Notification onClose={onClose}>{content}</Notification>);
+    wrapper = shallow(<Notification onClose={onClose}>{content}</Notification>).shallow();
   });
 
   it('should render children component', () => {

--- a/src/web/components/Notification/Notification.test.js
+++ b/src/web/components/Notification/Notification.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Notification from './';
+
+describe('Notification', () => {
+  let wrapper;
+  let content;
+  let onClose;
+
+  beforeEach(() => {
+    content = <p>Hello World</p>;
+    onClose = jest.fn();
+    wrapper = shallow(<Notification onClose={onClose}>{content}</Notification>);
+  });
+
+  it('should render children component', () => {
+    expect(wrapper.contains(content)).toBeTruthy();
+  });
+
+  it('should render a close button when onClose func is set ', () => {
+    expect(wrapper.find('button.delete')).toHaveLength(1);
+  });
+
+  it('should render a div with notification class by default', () => {
+    expect(wrapper.find('div.notification')).toHaveLength(1);
+  });
+
+  it('should render a div with notification + className', () => {
+    wrapper.setProps({ className: 'hello' });
+    expect(wrapper.find('div.hello.notification')).toHaveLength(1);
+  });
+
+  it('should not render a close button when onClose func is not set', () => {
+    wrapper.setProps({ onClose: null });
+    expect(wrapper.find('button.delete')).toHaveLength(0);
+  });
+
+  it('should trigger onClose function when the close button is clicked', () => {
+    const button = wrapper.find('button.delete');
+    button.simulate('click');
+    expect(onClose).toBeCalled();
+  });
+});

--- a/src/web/components/Notification/Notification.test.js
+++ b/src/web/components/Notification/Notification.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Notification from './';
+import { Notification } from './';
 
 describe('Notification', () => {
   let wrapper;
@@ -10,7 +10,7 @@ describe('Notification', () => {
   beforeEach(() => {
     content = <p>Hello World</p>;
     onClose = jest.fn();
-    wrapper = shallow(<Notification onClose={onClose}>{content}</Notification>).shallow();
+    wrapper = shallow(<Notification onClose={onClose}>{content}</Notification>);
   });
 
   it('should render children component', () => {

--- a/src/web/components/Notification/index.js
+++ b/src/web/components/Notification/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import connect from '../../hoc/Color';
+
+const Notification = ({ children, className, onClose }) => {
+  const classes = `notification${className && ` ${className}`}`;
+
+  const closeButton = onClose && <button className="delete" onClick={onClose} />;
+  return (
+    <div className={classes}>
+      {closeButton}
+      {children}
+    </div>
+  );
+};
+
+Notification.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  onClose: PropTypes.func,
+};
+
+Notification.defaultProps = {
+  className: '',
+  onClose: null,
+};
+
+export default connect(Notification);

--- a/src/web/components/Notification/index.js
+++ b/src/web/components/Notification/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import colorify from '../../hoc/Color';
 
-const Notification = ({ children, className, onClose }) => {
+export const Notification = ({ children, className, onClose }) => {
   const classes = `notification${className && ` ${className}`}`;
   const closeButton = onClose && <button className="delete" onClick={onClose} />;
   return (

--- a/src/web/components/Notification/index.js
+++ b/src/web/components/Notification/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import connect from '../../hoc/Color';
+import colorify from '../../hoc/Color';
 
 const Notification = ({ children, className, onClose }) => {
   const classes = `notification${className && ` ${className}`}`;
@@ -24,4 +24,4 @@ Notification.defaultProps = {
   onClose: null,
 };
 
-export default connect(Notification);
+export default colorify(Notification);

--- a/src/web/components/Notification/index.js
+++ b/src/web/components/Notification/index.js
@@ -4,7 +4,6 @@ import connect from '../../hoc/Color';
 
 const Notification = ({ children, className, onClose }) => {
   const classes = `notification${className && ` ${className}`}`;
-
   const closeButton = onClose && <button className="delete" onClick={onClose} />;
   return (
     <div className={classes}>

--- a/src/web/hoc/Color/Color.test.js
+++ b/src/web/hoc/Color/Color.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import connect from './';
+
+const divComponent = props => <div {...props}>Hello World</div>;
+
+describe('Color', () => {
+  it('should add a className if a color prop is set', () => {
+    const ColorDiv = connect(divComponent);
+    const wrapper = shallow(<ColorDiv color="primary">Test</ColorDiv>);
+    expect(wrapper.find('div.is-primary'));
+  });
+});

--- a/src/web/hoc/Color/Color.test.js
+++ b/src/web/hoc/Color/Color.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import connect from './';
+import colorify from './';
 
 const divComponent = props => <div {...props}>Hello World</div>;
 
 describe('Color', () => {
   it('should add a className if a color prop is set', () => {
-    const ColorDiv = connect(divComponent);
+    const ColorDiv = colorify(divComponent);
     const wrapper = shallow(<ColorDiv color="primary">Test</ColorDiv>);
     expect(wrapper.find('div.is-primary'));
   });

--- a/src/web/hoc/Color/index.js
+++ b/src/web/hoc/Color/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function connect(component) {
+  function Color({ color, className, ...props }) {
+    const classes = className + color && ` is-${color}`;
+    return <component {...props} className={classes} />;
+  }
+
+  Color.propTypes = {
+    className: PropTypes.string,
+    color: PropTypes.oneOf([
+      '',
+      'white',
+      'black',
+      'light',
+      'dark',
+      'primary',
+      'link',
+      'info',
+      'success',
+      'warning',
+      'danger',
+    ]),
+  };
+
+  Color.defaultProps = {
+    className: '',
+    color: '',
+  };
+
+  return Color;
+}

--- a/src/web/hoc/Color/index.js
+++ b/src/web/hoc/Color/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function connect(Component) {
-  function Color({ color, className, ...props }) {
-    const classes = className + color && ` is-${color}`;
+export default function colorify(Component) {
+  function Color(props) {
+    const classes = props.className + props.color && ` is-${props.color}`;
     return <Component {...props} className={classes} />;
   }
 

--- a/src/web/hoc/Color/index.js
+++ b/src/web/hoc/Color/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function connect(component) {
+export default function connect(Component) {
   function Color({ color, className, ...props }) {
     const classes = className + color && ` is-${color}`;
-    return <component {...props} className={classes} />;
+    return <Component {...props} className={classes} />;
   }
 
   Color.propTypes = {

--- a/stories/notification.stories.js
+++ b/stories/notification.stories.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import Notification from './../src/web/components/Notification';
+import Text from './../src/web/components/Text';
+
+storiesOf('Notification', module)
+  .add('basic notification', () => (
+    <Notification>
+      <Text>Hello world</Text>
+      <Text>
+        Laborum deserunt ut duis reprehenderit anim officia aliquip irure consectetur fugiat
+        consequat dolore dolore nisi. Sit est voluptate enim id. Esse cillum in officia incididunt
+        adipisicing non elit cupidatat. Eiusmod excepteur consectetur laboris adipisicing enim anim
+        aliquip consectetur ea incididunt laborum incididunt voluptate. Adipisicing laboris deserunt
+        ullamco ipsum nisi elit incididunt ex labore minim commodo. Eiusmod tempor elit officia
+        aliqua excepteur.
+      </Text>
+    </Notification>
+  ))
+  .add('with a close button', () => (
+    <Notification onClose={action('close')}>
+      <Text>Hello world</Text>
+      <Text>
+        Laborum deserunt ut duis reprehenderit anim officia aliquip irure consectetur fugiat
+        consequat dolore dolore nisi. Sit est voluptate enim id. Esse cillum in officia incididunt
+        adipisicing non elit cupidatat. Eiusmod excepteur consectetur laboris adipisicing enim anim
+        aliquip consectetur ea incididunt laborum incididunt voluptate. Adipisicing laboris deserunt
+        ullamco ipsum nisi elit incididunt ex labore minim commodo. Eiusmod tempor elit officia
+        aliqua excepteur.
+      </Text>
+    </Notification>
+  ))
+  .add('with a color', () => (
+    <Notification color="danger" onClose={action('color')}>
+      <Text>Hello world</Text>
+      <Text>
+        Laborum deserunt ut duis reprehenderit anim officia aliquip irure consectetur fugiat
+        consequat dolore dolore nisi. Sit est voluptate enim id. Esse cillum in officia incididunt
+        adipisicing non elit cupidatat. Eiusmod excepteur consectetur laboris adipisicing enim anim
+        aliquip consectetur ea incididunt laborum incididunt voluptate. Adipisicing laboris deserunt
+        ullamco ipsum nisi elit incididunt ex labore minim commodo. Eiusmod tempor elit officia
+        aliqua excepteur.
+      </Text>
+    </Notification>
+  ));


### PR DESCRIPTION
Add Notification component

Add Color HOC

HOC Color allows to implement Bulma's color classes for background colors. It can be used with Color props once a component is connected. 

Question: 
Given that there may be a HOC typography that will also use props color to put color on the text, should I rename the props to background for this HOC ? 
Normally, the 2 HOCs should not be used simultaneously and has more or less the same values.

If this HOC is validated, it can be used for Button Component and other future components.
