### PR TITLE
feat(presentational): add progress component

### DIFF
--- a/src/web/components/Progress/Progress.test.js
+++ b/src/web/components/Progress/Progress.test.js
@@ -31,4 +31,13 @@ describe('Progress', () => {
     wrapper.setProps({ className: 'hello' });
     expect(wrapper.find('progress').prop('className')).toBe('progress hello');
   });
+
+  it('should render a progress bar with 100 as max value by default', () => {
+    expect(wrapper.find('progress').prop('max')).toBe(100);
+  });
+
+  it('should render a progress bar with 100 as max value', () => {
+    wrapper.setProps({ max: 200 });
+    expect(wrapper.find('progress').prop('max')).toBe(200);
+  });
 });

--- a/src/web/components/Progress/Progress.test.js
+++ b/src/web/components/Progress/Progress.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Progress from './';
+
+describe('Progress', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<Progress value="50" />);
+  });
+
+  it('should render a progress bar with 0% completed', () => {
+    wrapper.setProps({ value: '0' });
+    expect(wrapper.find('progress').prop('value')).toBe('0');
+  });
+
+  it('should render a progress bar with 50% completed', () => {
+    expect(wrapper.find('progress').prop('value')).toBe('50');
+  });
+
+  it('should render a progress bar with 100% completed', () => {
+    wrapper.setProps({ value: '100' });
+    expect(wrapper.find('progress').prop('value')).toBe('100');
+  });
+
+  it('should render only progress class if className is not set', () => {
+    expect(wrapper.find('progress').prop('className')).toBe('progress');
+  });
+
+  it('should render progress class + className', () => {
+    wrapper.setProps({ className: 'hello' });
+    expect(wrapper.find('progress').prop('className')).toBe('progress hello');
+  });
+});

--- a/src/web/components/Progress/Progress.test.js
+++ b/src/web/components/Progress/Progress.test.js
@@ -6,21 +6,21 @@ describe('Progress', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<Progress value="50" />);
+    wrapper = shallow(<Progress value={50} />);
   });
 
   it('should render a progress bar with 0% completed', () => {
-    wrapper.setProps({ value: '0' });
-    expect(wrapper.find('progress').prop('value')).toBe('0');
+    wrapper.setProps({ value: 0 });
+    expect(wrapper.find('progress').prop('value')).toBe(0);
   });
 
   it('should render a progress bar with 50% completed', () => {
-    expect(wrapper.find('progress').prop('value')).toBe('50');
+    expect(wrapper.find('progress').prop('value')).toBe(50);
   });
 
   it('should render a progress bar with 100% completed', () => {
-    wrapper.setProps({ value: '100' });
-    expect(wrapper.find('progress').prop('value')).toBe('100');
+    wrapper.setProps({ value: 100 });
+    expect(wrapper.find('progress').prop('value')).toBe(100);
   });
 
   it('should render only progress class if className is not set', () => {

--- a/src/web/components/Progress/index.js
+++ b/src/web/components/Progress/index.js
@@ -1,18 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Progress = ({ value, className }) => {
+const Progress = ({ value, max, className }) => {
   const classes = `progress${className && ` ${className}`}`;
-  return <progress value={value} className={classes} />;
+  return <progress value={value} className={classes} max={max} />;
 };
 
 Progress.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+  max: PropTypes.number,
   className: PropTypes.string,
 };
 
 Progress.defaultProps = {
   className: '',
+  max: 100,
 };
 
 export default Progress;

--- a/src/web/components/Progress/index.js
+++ b/src/web/components/Progress/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Progress = ({ value, className }) => {
+  const classes = `progress${className && ` ${className}`}`;
+  return <progress value={value} className={classes} />;
+};
+
+Progress.propTypes = {
+  value: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+Progress.defaultProps = {
+  className: '',
+};
+
+export default Progress;

--- a/stories/progress.stories.js
+++ b/stories/progress.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Progress from './../src/web/components/Progress';
+
+storiesOf('Progress', module).add('basic progress', () => (
+  <div>
+    <Progress value={0} />
+    <Progress value={25} />
+    <Progress value={50} />
+    <Progress value={75} />
+    <Progress value={100} />
+  </div>
+));


### PR DESCRIPTION
Add an element of progress 
The color of the progress bar will be implemented with Color HOC when the pr is OK.

Can be improved with HOC size to implement the different sizes available in bulma